### PR TITLE
solucionado - rutas y parametros por rutas de producto y local.

### DIFF
--- a/frontEnd/src/app/app.routes.ts
+++ b/frontEnd/src/app/app.routes.ts
@@ -32,7 +32,7 @@ export const routes: Routes = [
     component: LocalComponent, 
     canActivate: [authGuard]},
 
-    {path: 'producto', 
+    {path: 'producto/:{{idProd}}', 
     component: ProductoComponent, 
     canActivate: [authGuard]},
 

--- a/frontEnd/src/app/core/services/local-service/local.service.ts
+++ b/frontEnd/src/app/core/services/local-service/local.service.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs';
 })
 export class LocalService {
   private URL_ALL_LOCAL = "http://localhost:3000/local";
-  private URL_LOCAL = "http://localhost:3000/local/:";
+  private URL_LOCAL = "http://localhost:3000/local/";
   constructor(private http : HttpClient){  }
 
 

--- a/frontEnd/src/app/features/pages/local/local.component.html
+++ b/frontEnd/src/app/features/pages/local/local.component.html
@@ -71,7 +71,7 @@
       <div class="productos-container">
         
         <!-- FALTA ARREGLAR EL ENRUTAMIENTO -->
-        <a class="enlace-producto" routerLink="product/{{producto.product_id}}">
+        <a class="enlace-producto" routerLink="/producto/{{producto.product_id}}">
         
           
           <div class="info">

--- a/frontEnd/src/app/features/pages/local/local.component.ts
+++ b/frontEnd/src/app/features/pages/local/local.component.ts
@@ -28,24 +28,22 @@ export class LocalComponent implements OnInit {
   private prodServ$ = inject(ProductosService);
   // Este hijo recibe el id del local
   private local_id : string = '';
-  local!:Local;
+  local:Local = new Local();
   product : Product[] = [];
+
+  
   @Input('idProd') idProduct! :string;
   
   ngOnInit() : void{
     
     this.route.params.subscribe( (params) => 
       {
-        
-        this.local_id = params['{idLocal}']
-  
+        this.local_id = params['{idLocal}'];
       });
 
 
     this.localSer$.getLocal(this.local_id).subscribe(
       (resp) => {
-        console.log(this.local_id);
-        console.log(resp);
         this.local = resp;
       }
     )
@@ -53,7 +51,6 @@ export class LocalComponent implements OnInit {
     this.prodServ$.getProductsFromLocal(this.local_id).subscribe(
       ( resp ) => {
         this.product = resp;
-        console.log(this.product);
       }
     )
 


### PR DESCRIPTION
Se arregló el ruteo que tenía el producto y la llamada del parámetro  'idLocal', además se muestra la información de cada producto perteneciente a un local seleccionado previamente en la sección de inicio.